### PR TITLE
Boost 1.58 patch

### DIFF
--- a/boost_patched/serialization/collections_load_imp.hpp
+++ b/boost_patched/serialization/collections_load_imp.hpp
@@ -1,0 +1,106 @@
+#ifndef  BOOST_SERIALIZATION_COLLECTIONS_LOAD_IMP_HPP
+#define BOOST_SERIALIZATION_COLLECTIONS_LOAD_IMP_HPP
+
+// MS compatible compilers support #pragma once
+#if defined(_MSC_VER)
+# pragma once
+#endif
+
+#if defined(_MSC_VER) && (_MSC_VER <= 1020)
+#  pragma warning (disable : 4786) // too long name, harmless warning
+#endif
+
+/////////1/////////2/////////3/////////4/////////5/////////6/////////7/////////8
+// collections_load_imp.hpp: serialization for loading stl collections
+
+// (C) Copyright 2002 Robert Ramey - http://www.rrsd.com . 
+// Use, modification and distribution is subject to the Boost Software
+// License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+//  See http://www.boost.org for updates, documentation, and revision history.
+
+// helper function templates for serialization of collections
+
+#include <boost/assert.hpp>
+#include <cstddef> // size_t
+#include <boost/config.hpp> // msvc 6.0 needs this for warning suppression
+#if defined(BOOST_NO_STDC_NAMESPACE)
+namespace std{ 
+    using ::size_t; 
+} // namespace std
+#endif
+#include <boost/detail/workaround.hpp>
+
+#include <boost/archive/detail/basic_iarchive.hpp>
+#include <boost/serialization/access.hpp>
+#include <boost/serialization/nvp.hpp>
+#include <boost/serialization/detail/stack_constructor.hpp>
+#include <boost/serialization/collection_size_type.hpp>
+#include <boost/serialization/item_version_type.hpp>
+#include <boost/serialization/detail/is_default_constructible.hpp>
+#include <boost/utility/enable_if.hpp>
+
+namespace boost{
+namespace serialization {
+namespace stl {
+
+//////////////////////////////////////////////////////////////////////
+// implementation of serialization for STL containers
+//
+
+template<
+    class Archive,
+    class T
+>
+typename boost::enable_if<
+    typename detail::is_default_constructible<
+        typename T::value_type
+    >,
+    void
+>::type
+collection_load_impl(
+    Archive & ar,
+    T & t,
+    collection_size_type count,
+    item_version_type
+){
+    t.resize(count);
+    typename T::iterator hint;
+    hint = t.begin();
+    while(count-- > 0){
+        ar >> boost::serialization::make_nvp("item", *hint++);
+    }
+}
+
+template<
+    class Archive,
+    class T
+>
+typename boost::disable_if<
+    typename detail::is_default_constructible<
+        typename T::value_type
+    >,
+    void
+>::type
+collection_load_impl(
+    Archive & ar,
+    T & t,
+    collection_size_type count,
+    item_version_type item_version
+){
+    t.clear();
+    while(count-- > 0){
+        detail::stack_construct<Archive, typename T::value_type> u(ar, item_version);
+        ar >> boost::serialization::make_nvp("item", u.reference());
+        t.push_back(u.reference());
+        ar.reset_object_address(& t.back() , & u.reference());
+     }
+}
+
+} // namespace stl 
+} // namespace serialization
+} // namespace boost
+
+#endif //BOOST_SERIALIZATION_COLLECTIONS_LOAD_IMP_HPP
+

--- a/boost_patched/serialization/collections_save_imp.hpp
+++ b/boost_patched/serialization/collections_save_imp.hpp
@@ -1,0 +1,83 @@
+#ifndef BOOST_SERIALIZATION_COLLECTIONS_SAVE_IMP_HPP
+#define BOOST_SERIALIZATION_COLLECTIONS_SAVE_IMP_HPP
+
+// MS compatible compilers support #pragma once
+#if defined(_MSC_VER)
+# pragma once
+#endif
+
+/////////1/////////2/////////3/////////4/////////5/////////6/////////7/////////8
+// collections_save_imp.hpp: serialization for stl collections
+
+// (C) Copyright 2002 Robert Ramey - http://www.rrsd.com . 
+// Use, modification and distribution is subject to the Boost Software
+// License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+//  See http://www.boost.org for updates, documentation, and revision history.
+
+// helper function templates for serialization of collections
+
+#include <boost/config.hpp>
+#include <boost/serialization/nvp.hpp>
+#include <boost/serialization/serialization.hpp>
+#include <boost/serialization/version.hpp>
+#include <boost/serialization/collection_size_type.hpp>
+#include <boost/serialization/item_version_type.hpp>
+
+namespace boost{
+namespace serialization {
+namespace stl {
+
+//////////////////////////////////////////////////////////////////////
+// implementation of serialization for STL containers
+//
+
+template<class Archive, class Container>
+inline void save_collection(
+    Archive & ar,
+    const Container &s,
+    collection_size_type count)
+{
+    ar << BOOST_SERIALIZATION_NVP(count);
+    // record number of elements
+    const item_version_type item_version(
+        version<typename Container::value_type>::value
+    );
+    #if 0
+        boost::archive::library_version_type library_version(
+            ar.get_library_version()
+        );
+        if(boost::archive::library_version_type(3) < library_version){
+            ar << BOOST_SERIALIZATION_NVP(item_version);
+        }
+    #else
+        ar << BOOST_SERIALIZATION_NVP(item_version);
+    #endif
+
+    typename Container::const_iterator it = s.begin();
+    while(count-- > 0){
+        // note borland emits a no-op without the explicit namespace
+        boost::serialization::save_construct_data_adl(
+            ar, 
+            &(*it), 
+            item_version
+        );
+        ar << boost::serialization::make_nvp("item", *it++);
+    }
+}
+
+template<class Archive, class Container>
+inline void save_collection(Archive & ar, const Container &s)
+{
+    // record number of elements
+    collection_size_type count(s.size());
+    save_collection(ar, s, count);
+}
+
+} // namespace stl 
+} // namespace serialization
+} // namespace boost
+
+#endif //BOOST_SERIALIZATION_COLLECTIONS_SAVE_IMP_HPP
+

--- a/boost_patched/serialization/readme.md
+++ b/boost_patched/serialization/readme.md
@@ -1,0 +1,5 @@
+Uggly copy of boost file because the vector serialization is buggy in boost 1.58 (and has been corrected in boost 1.59)
+
+what is missing is the serialization of non default constructible objects in the vector
+
+cf: http://lists.boost.org/boost-users/2015/06/84377.php

--- a/boost_patched/serialization/vector.hpp
+++ b/boost_patched/serialization/vector.hpp
@@ -1,0 +1,228 @@
+#ifndef  BOOST_SERIALIZATION_VECTOR_HPP
+#define BOOST_SERIALIZATION_VECTOR_HPP
+
+// MS compatible compilers support #pragma once
+#if defined(_MSC_VER)
+# pragma once
+#endif
+
+/////////1/////////2/////////3/////////4/////////5/////////6/////////7/////////8
+// vector.hpp: serialization for stl vector templates
+
+// (C) Copyright 2002 Robert Ramey - http://www.rrsd.com . 
+// fast array serialization (C) Copyright 2005 Matthias Troyer 
+// Use, modification and distribution is subject to the Boost Software
+// License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+//  See http://www.boost.org for updates, documentation, and revision history.
+
+#include <vector>
+
+#include <boost/config.hpp>
+#include <boost/detail/workaround.hpp>
+
+#include <boost/archive/detail/basic_iarchive.hpp>
+#include <boost/serialization/access.hpp>
+#include <boost/serialization/nvp.hpp>
+#include <boost/serialization/collection_size_type.hpp>
+#include <boost/serialization/item_version_type.hpp>
+
+#include "collections_save_imp.hpp"
+#include "collections_load_imp.hpp"
+#include <boost/serialization/split_free.hpp>
+#include <boost/serialization/array.hpp>
+#include <boost/serialization/detail/get_data.hpp>
+#include <boost/serialization/detail/stack_constructor.hpp>
+#include <boost/mpl/bool.hpp>
+#include <boost/mpl/if.hpp>
+
+// default is being compatible with version 1.34.1 files, not 1.35 files
+#ifndef BOOST_SERIALIZATION_VECTOR_VERSIONED
+#define BOOST_SERIALIZATION_VECTOR_VERSIONED(V) (V==4 || V==5)
+#endif
+
+// function specializations must be defined in the appropriate
+// namespace - boost::serialization
+#if defined(__SGI_STL_PORT) || defined(_STLPORT_VERSION)
+#define STD _STLP_STD
+#else
+#define STD std
+#endif
+
+namespace boost { 
+namespace serialization {
+
+/////////1/////////2/////////3/////////4/////////5/////////6/////////7/////////8
+// vector< T >
+
+// the default versions
+
+template<class Archive, class U, class Allocator>
+inline void save(
+    Archive & ar,
+    const std::vector<U, Allocator> &t,
+    const unsigned int /* file_version */,
+    mpl::false_
+){
+    boost::serialization::stl::save_collection<Archive, STD::vector<U, Allocator> >(
+        ar, t
+    );
+}
+
+template<class Archive, class U, class Allocator>
+inline void load(
+    Archive & ar,
+    std::vector<U, Allocator> &t,
+    const unsigned int /* file_version */,
+    mpl::false_
+){
+    const boost::archive::library_version_type library_version(
+        ar.get_library_version()
+    );
+    // retrieve number of elements
+    item_version_type item_version(0);
+    collection_size_type count;
+    ar >> BOOST_SERIALIZATION_NVP(count);
+    if(boost::archive::library_version_type(3) < library_version){
+        ar >> BOOST_SERIALIZATION_NVP(item_version);
+    }
+    t.reserve(count);
+    stl::collection_load_impl(ar, t, count, item_version);
+}
+
+// the optimized versions
+
+template<class Archive, class U, class Allocator>
+inline void save(
+    Archive & ar,
+    const std::vector<U, Allocator> &t,
+    const unsigned int /* file_version */,
+    mpl::true_
+){
+    const collection_size_type count(t.size());
+    ar << BOOST_SERIALIZATION_NVP(count);
+    if (!t.empty())
+        ar << make_array(detail::get_data(t),t.size());
+}
+
+template<class Archive, class U, class Allocator>
+inline void load(
+    Archive & ar,
+    std::vector<U, Allocator> &t,
+    const unsigned int /* file_version */,
+    mpl::true_
+){
+    collection_size_type count(t.size());
+    ar >> BOOST_SERIALIZATION_NVP(count);
+    t.resize(count);
+    unsigned int item_version=0;
+    if(BOOST_SERIALIZATION_VECTOR_VERSIONED(ar.get_library_version())) {
+        ar >> BOOST_SERIALIZATION_NVP(item_version);
+    }
+    if (!t.empty())
+        ar >> make_array(detail::get_data(t),t.size());
+  }
+
+// dispatch to either default or optimized versions
+
+template<class Archive, class U, class Allocator>
+inline void save(
+    Archive & ar,
+    const std::vector<U, Allocator> &t,
+    const unsigned int file_version
+){
+    typedef typename 
+    boost::serialization::use_array_optimization<Archive>::template apply<
+        typename remove_const<U>::type 
+    >::type use_optimized;
+    save(ar,t,file_version, use_optimized());
+}
+
+template<class Archive, class U, class Allocator>
+inline void load(
+    Archive & ar,
+    std::vector<U, Allocator> &t,
+    const unsigned int file_version
+){
+#ifdef BOOST_SERIALIZATION_VECTOR_135_HPP
+    if (ar.get_library_version()==boost::archive::library_version_type(5))
+    {
+      load(ar,t,file_version, boost::is_arithmetic<U>());
+      return;
+    }
+#endif
+    typedef typename 
+    boost::serialization::use_array_optimization<Archive>::template apply<
+        typename remove_const<U>::type 
+    >::type use_optimized;
+    load(ar,t,file_version, use_optimized());
+}
+
+// split non-intrusive serialization function member into separate
+// non intrusive save/load member functions
+template<class Archive, class U, class Allocator>
+inline void serialize(
+    Archive & ar,
+    std::vector<U, Allocator> & t,
+    const unsigned int file_version
+){
+    boost::serialization::split_free(ar, t, file_version);
+}
+
+/////////1/////////2/////////3/////////4/////////5/////////6/////////7/////////8
+// vector<bool>
+template<class Archive, class Allocator>
+inline void save(
+    Archive & ar,
+    const std::vector<bool, Allocator> &t,
+    const unsigned int /* file_version */
+){
+    // record number of elements
+    collection_size_type count (t.size());
+    ar << BOOST_SERIALIZATION_NVP(count);
+    std::vector<bool>::const_iterator it = t.begin();
+    while(count-- > 0){
+        bool tb = *it++;
+        ar << boost::serialization::make_nvp("item", tb);
+    }
+}
+
+template<class Archive, class Allocator>
+inline void load(
+    Archive & ar,
+    std::vector<bool, Allocator> &t,
+    const unsigned int /* file_version */
+){
+    // retrieve number of elements
+    collection_size_type count;
+    ar >> BOOST_SERIALIZATION_NVP(count);
+    t.resize(count);
+    for(collection_size_type i = collection_size_type(0); i < count; ++i){
+        bool b;
+        ar >> boost::serialization::make_nvp("item", b);
+        t[i] = b;
+    }
+}
+
+// split non-intrusive serialization function member into separate
+// non intrusive save/load member functions
+template<class Archive, class Allocator>
+inline void serialize(
+    Archive & ar,
+    std::vector<bool, Allocator> & t,
+    const unsigned int file_version
+){
+    boost::serialization::split_free(ar, t, file_version);
+}
+
+} // serialization
+} // namespace boost
+
+#include <boost/serialization/collection_traits.hpp>
+
+BOOST_SERIALIZATION_COLLECTION_TRAITS(std::vector)
+#undef STD
+
+#endif // BOOST_SERIALIZATION_VECTOR_HPP
+

--- a/serialization_flat_map.h
+++ b/serialization_flat_map.h
@@ -58,7 +58,16 @@ inline void load(
     boost::container::flat_map<Types...> &t,
     const unsigned int /* file_version */
 ){
+#if BOOST_VERSION >= 105800
     load_map_collection(ar, t);
+#else
+    boost::serialization::stl::load_collection<
+        Archive,
+        boost::container::flat_map<Types...>,
+        boost::serialization::stl::archive_input_map<Archive, boost::container::flat_map<Types...>>,
+        boost::serialization::stl::reserve_imp<boost::container::flat_map<Types...>>
+    >(ar, t);
+#endif
 }
 
 // split non-intrusive serialization function member into separate

--- a/serialization_flat_map.h
+++ b/serialization_flat_map.h
@@ -39,10 +39,7 @@ www.navitia.io
 
 #include <boost/container/flat_map.hpp>
 
-#include <boost/serialization/utility.hpp>
-#include <boost/serialization/collections_save_imp.hpp>
-#include <boost/serialization/collections_load_imp.hpp>
-#include <boost/serialization/split_free.hpp>
+#include <boost/serialization/map.hpp>
 
 namespace boost { namespace serialization {
 
@@ -61,12 +58,7 @@ inline void load(
     boost::container::flat_map<Types...> &t,
     const unsigned int /* file_version */
 ){
-    boost::serialization::stl::load_collection<
-        Archive,
-        boost::container::flat_map<Types...>,
-        boost::serialization::stl::archive_input_map<Archive, boost::container::flat_map<Types...>>,
-        boost::serialization::stl::reserve_imp<boost::container::flat_map<Types...>>
-    >(ar, t);
+    load_map_collection(ar, t);
 }
 
 // split non-intrusive serialization function member into separate

--- a/serialization_unordered_map.h
+++ b/serialization_unordered_map.h
@@ -37,8 +37,10 @@ www.navitia.io
 
 #pragma once
 
+#if BOOST_VERSION >= 105700
+#include <boost/serialization/unordered_map.hpp>
+#else
 #include <unordered_map>
-
 #include <boost/serialization/utility.hpp>
 #include <boost/serialization/collections_save_imp.hpp>
 #include <boost/serialization/collections_load_imp.hpp>
@@ -81,3 +83,4 @@ inline void serialize(
 }
 
 }} // namespace boost::serialization
+#endif

--- a/serialization_unordered_set.h
+++ b/serialization_unordered_set.h
@@ -37,8 +37,10 @@ www.navitia.io
 
 #pragma once
 
+#if BOOST_VERSION >= 105700
+#include <boost/serialization/unordered_set.hpp>
+#else
 #include <unordered_set>
-
 #include <boost/serialization/utility.hpp>
 #include <boost/serialization/collections_save_imp.hpp>
 #include <boost/serialization/collections_load_imp.hpp>
@@ -81,3 +83,4 @@ inline void serialize(
 }
 
 }} // namespace boost::serialization
+#endif

--- a/serialization_vector.h
+++ b/serialization_vector.h
@@ -1,0 +1,42 @@
+/* Copyright © 2001-2014, Canal TP and/or its affiliates. All rights reserved.
+  
+This file is part of Navitia,
+    the software to build cool stuff with public transport.
+ 
+Hope you'll enjoy and contribute to this project,
+    powered by Canal TP (www.canaltp.fr).
+Help us simplify mobility and open public transport:
+    a non ending quest to the responsive locomotion way of traveling!
+  
+LICENCE: This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+   
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+   
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+  
+Stay tuned using
+twitter @navitia 
+IRC #navitia on freenode
+https://groups.google.com/d/forum/navitia
+www.navitia.io
+*/
+
+
+#pragma once
+
+#include <boost/version.hpp>
+#if BOOST_VERSION == 105800
+// boost's 1.58 vector serialization cannot handle non default constructible object
+// it has been patched in boost 1.59, so the patched files has been copied in 
+// navitia
+#include "boost_patched/serialization/vector.hpp"
+#else
+#include <boost/serialization/vector.hpp>
+#endif


### PR DESCRIPTION
boost 1.58 vector serialization does not work
we copied some files from boost 1.59 to make it work.

some serialization stuff have been implemented (unordered_{map|set}), we
now use boost implementation when possible

cf: http://lists.boost.org/boost-users/2015/06/84377.php