### PR TITLE
explicitly use std::forward not to have conflict

### DIFF
--- a/functions.h
+++ b/functions.h
@@ -113,7 +113,7 @@ struct Indexer{
 namespace std {
 template <typename T, typename ...Args>
 unique_ptr<T> make_unique(Args&& ...args) {
-    return unique_ptr<T>(new T(forward<Args>(args)...));
+    return unique_ptr<T>(new T(std::forward<Args>(args)...));
 }
 }
 #endif


### PR DESCRIPTION
boost also has a boost::forward, so we want to explicitly use
std::forward