### PR TITLE
compatibility with boost1.61

### DIFF
--- a/tests/csvreader_test.cpp
+++ b/tests/csvreader_test.cpp
@@ -39,7 +39,7 @@ struct logger_initialized {
     logger_initialized()   { init_logger(); }
 
 };
-BOOST_GLOBAL_FIXTURE( logger_initialized )
+BOOST_GLOBAL_FIXTURE( logger_initialized );
 
 /*
 Slash between double quote, exemple:

--- a/tests/utils_test.cpp
+++ b/tests/utils_test.cpp
@@ -42,7 +42,7 @@ www.navitia.io
 struct logger_initialized {
     logger_initialized()   { init_logger(); }
 };
-BOOST_GLOBAL_FIXTURE( logger_initialized )
+BOOST_GLOBAL_FIXTURE( logger_initialized );
 
 enum class Mode {
     bike = 0,


### PR DESCRIPTION
boost becomes less flexible with ';'

will generate pedantic warnings in previous versions, but...