### PR TITLE
Upgrade logger (syslog option) + adding namespace

### DIFF
--- a/init.h
+++ b/init.h
@@ -1,41 +1,40 @@
 /* Copyright © 2001-2014, Canal TP and/or its affiliates. All rights reserved.
-  
+
 This file is part of Navitia,
     the software to build cool stuff with public transport.
- 
+
 Hope you'll enjoy and contribute to this project,
     powered by Canal TP (www.canaltp.fr).
 Help us simplify mobility and open public transport:
     a non ending quest to the responsive locomotion way of traveling!
-  
+
 LICENCE: This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
-   
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU Affero General Public License for more details.
-   
+
 You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
-  
+
 Stay tuned using
-twitter @navitia 
+twitter @navitia
 IRC #navitia on freenode
 https://groups.google.com/d/forum/navitia
 www.navitia.io
 */
-
 #pragma once
+
 #include "conf.h"
 #include "logger.h"
 #include "backtrace.h"
 #include <csignal>
 #include <unistd.h>
 #include <iostream>
-
 
 /**
  * Provide facilities to initialize an app
@@ -56,6 +55,7 @@ inline void print_backtrace() {
 }
 
 namespace {
+
 void before_dying(int signum) {
     log4cplus::Logger logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("logger"));
     LOG4CPLUS_FATAL(logger, "We received signal: " << signum << ", so it's time to die!! version: "
@@ -73,6 +73,7 @@ void before_exit(int signum) {
     signal(signum, SIG_DFL);
     exit(0);
 }
+
 }
 
 inline void init_signal_handling() {
@@ -86,9 +87,14 @@ inline void init_signal_handling() {
     signal(SIGINT, before_exit);
 }
 
-inline void init_app() {
-    init_logger();
+inline void init_app(const std::string& name = "",
+                     const std::string& level = "DEBUG",
+                     const bool active_local_syslog = false)
+{
+    init_logger(name, level, active_local_syslog);
 
     init_signal_handling();
 }
-}
+
+} // namespace navitia
+

--- a/init.h
+++ b/init.h
@@ -87,11 +87,12 @@ inline void init_signal_handling() {
     signal(SIGINT, before_exit);
 }
 
-inline void init_app(const std::string& name = "",
-                     const std::string& level = "DEBUG",
-                     const bool active_local_syslog = false)
+inline void init_app(const std::string& log_name = "",
+                     const std::string& log_level = "DEBUG",
+                     const bool active_local_syslog = false,
+                     const std::string& log_comment = "")
 {
-    init_logger(name, level, active_local_syslog);
+    init_logger(log_name, log_level, active_local_syslog, log_comment);
 
     init_signal_handling();
 }

--- a/logger.h
+++ b/logger.h
@@ -1,62 +1,123 @@
 /* Copyright © 2001-2014, Canal TP and/or its affiliates. All rights reserved.
-  
+
 This file is part of Navitia,
     the software to build cool stuff with public transport.
- 
+
 Hope you'll enjoy and contribute to this project,
     powered by Canal TP (www.canaltp.fr).
 Help us simplify mobility and open public transport:
     a non ending quest to the responsive locomotion way of traveling!
-  
+
 LICENCE: This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
-   
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU Affero General Public License for more details.
-   
+
 You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
-  
+
 Stay tuned using
-twitter @navitia 
+twitter @navitia
 IRC #navitia on freenode
 https://groups.google.com/d/forum/navitia
 www.navitia.io
 */
-
 #pragma once
+
 #include "conf.h"
+#include <boost/format.hpp>
+
 #include <log4cplus/logger.h>
 #include <log4cplus/configurator.h>
-#include <boost/format.hpp>
 #ifdef HAVE_LOGGINGMACROS_H
 #include <log4cplus/loggingmacros.h>
 #endif
 
-/** Crée une configuration par défaut pour le logger */
-inline void init_logger(){
-    log4cplus::BasicConfigurator config;
-    config.configure();
-}
+namespace navitia {
 
-/** configure the logger with a level and a pattern, the output will be on stdout */
-inline void init_logger(const std::string& level, const std::string& pattern){
+// logger pattern example : [18-09-10 17:02:17,186] [INFO ] [NDC] - message file.cpp:248
+static const std::string console_pattern_ref = "[%D{%y-%m-%d %H:%M:%S,%q}] [%-5p] [%x] - %m %b:%L  %n";
+
+// syslog pattern example : Sep 11 14:16:11 hostname binary_name: [PID] [INFO] [NDC] - message file.cpp:261
+static const std::string syslog_pattern_ref  = "[%i] [%p] [%x] - %m %b:%L  %n";
+
+/**
+ * @brief init simple navitia logger
+ */
+inline void init_logger()
+{
     log4cplus::BasicConfigurator config;
     config.configure();
+
     auto properties = log4cplus::helpers::Properties();
-    properties.setProperty("log4cplus.rootLogger", (boost::format("%s, default") % level).str());
-    properties.setProperty("log4cplus.appender.default", "log4cplus::ConsoleAppender");
-    properties.setProperty("log4cplus.appender.default.layout", "log4cplus::PatternLayout");
-    properties.setProperty("log4cplus.appender.default.layout.ConversionPattern", pattern);
+    properties.setProperty("log4cplus.rootLogger", "DEBUG, console");
+    properties.setProperty("log4cplus.appender.console", "log4cplus::ConsoleAppender");
+    properties.setProperty("log4cplus.appender.console.layout", "log4cplus::PatternLayout");
+    properties.setProperty("log4cplus.appender.console.layout.ConversionPattern", console_pattern_ref);
+
     log4cplus::PropertyConfigurator configurator(properties);
     configurator.configure();
 }
 
-/** Configure le logger à partir du fichier de configuration */
-inline void init_logger(const std::string & config_file){
+/**
+ * @brief init navitia logger
+ *
+ * @param name The application name
+ * @param level The level of the logger (INFO, DEBUG, etc..)
+ * @param active_local_syslog Active syslog redirection
+ * @param pattern Overload pattern logger
+ */
+inline void init_logger(const std::string& name,
+                        const std::string& level,
+                        const bool active_local_syslog = false,
+                        const std::string& pattern = "")
+{
+    log4cplus::BasicConfigurator config;
+    config.configure();
+
+    auto properties = log4cplus::helpers::Properties();
+
+    if (active_local_syslog) {
+        properties.setProperty("log4cplus.rootLogger", (boost::format("%s, console, syslog") % level).str());
+        properties.setProperty("log4cplus.appender.syslog", "log4cplus::SysLogAppender");
+        properties.setProperty("log4cplus.appender.syslog.ident", name);
+        properties.setProperty("log4cplus.appender.syslog.facility", "local7");
+        properties.setProperty("log4cplus.appender.syslog.layout", "log4cplus::PatternLayout");
+        if (pattern.empty()) {
+            properties.setProperty("log4cplus.appender.syslog.layout.ConversionPattern", syslog_pattern_ref);
+        } else {
+            properties.setProperty("log4cplus.appender.syslog.layout.ConversionPattern", pattern);
+        }
+
+    } else {
+        properties.setProperty("log4cplus.rootLogger", (boost::format("%s, console") % level).str());
+    }
+    properties.setProperty("log4cplus.appender.console", "log4cplus::ConsoleAppender");
+    properties.setProperty("log4cplus.appender.console.ident", name);
+    properties.setProperty("log4cplus.appender.console.layout", "log4cplus::PatternLayout");
+    if (pattern.empty()) {
+        properties.setProperty("log4cplus.appender.console.layout.ConversionPattern", console_pattern_ref);
+    } else {
+        properties.setProperty("log4cplus.appender.console.layout.ConversionPattern", pattern);
+    }
+
+    log4cplus::PropertyConfigurator configurator(properties);
+    configurator.configure();
+}
+
+/**
+ * @brief init navitia logger with a config file
+ *
+ * @param config_file The configuration file path
+ */
+inline void init_logger(const std::string& config_file)
+{
     log4cplus::PropertyConfigurator::doConfigure(config_file);
 }
+
+} // namespace navitia

--- a/logger.h
+++ b/logger.h
@@ -84,6 +84,13 @@ inline void init_logger(const std::string& name,
         prefix = prefix + "[" + comment + "] ";
     }
 
+    auto syslog_pattern = prefix + syslog_pattern_ref;
+    auto console_pattern = console_pattern_ref1 + prefix + console_pattern_ref2;
+    if (!pattern.empty()) {
+        syslog_pattern = prefix + pattern;
+        console_pattern = prefix + pattern;
+    }
+
     log4cplus::BasicConfigurator config;
     config.configure();
 
@@ -95,21 +102,13 @@ inline void init_logger(const std::string& name,
         properties.setProperty("log4cplus.appender.syslog.ident", name);
         properties.setProperty("log4cplus.appender.syslog.facility", "local7");
         properties.setProperty("log4cplus.appender.syslog.layout", "log4cplus::PatternLayout");
-        if (pattern.empty()) {
-            properties.setProperty("log4cplus.appender.syslog.layout.ConversionPattern", prefix + syslog_pattern_ref);
-        } else {
-            properties.setProperty("log4cplus.appender.syslog.layout.ConversionPattern", prefix + pattern);
-        }
+        properties.setProperty("log4cplus.appender.syslog.layout.ConversionPattern", syslog_pattern);
     } else {
         properties.setProperty("log4cplus.rootLogger", (boost::format("%s, console") % level).str());
         properties.setProperty("log4cplus.appender.console", "log4cplus::ConsoleAppender");
         properties.setProperty("log4cplus.appender.console.ident", name);
         properties.setProperty("log4cplus.appender.console.layout", "log4cplus::PatternLayout");
-        if (pattern.empty()) {
-            properties.setProperty("log4cplus.appender.console.layout.ConversionPattern", console_pattern_ref1 + prefix + console_pattern_ref2);
-        } else {
-            properties.setProperty("log4cplus.appender.console.layout.ConversionPattern", prefix + pattern);
-        }
+        properties.setProperty("log4cplus.appender.console.layout.ConversionPattern", console_pattern);
     }
 
     log4cplus::PropertyConfigurator configurator(properties);

--- a/tests/csvreader_test.cpp
+++ b/tests/csvreader_test.cpp
@@ -36,7 +36,7 @@ www.navitia.io
 #include "utils/csv.h"
 
 struct logger_initialized {
-    logger_initialized()   { init_logger(); }
+    logger_initialized()   { navitia::init_logger(); }
 
 };
 BOOST_GLOBAL_FIXTURE( logger_initialized );

--- a/tests/utils_test.cpp
+++ b/tests/utils_test.cpp
@@ -1,28 +1,28 @@
 /* Copyright © 2001-2014, Canal TP and/or its affiliates. All rights reserved.
-  
+
 This file is part of Navitia,
     the software to build cool stuff with public transport.
- 
+
 Hope you'll enjoy and contribute to this project,
     powered by Canal TP (www.canaltp.fr).
 Help us simplify mobility and open public transport:
     a non ending quest to the responsive locomotion way of traveling!
-  
+
 LICENCE: This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
-   
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU Affero General Public License for more details.
-   
+
 You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
-  
+
 Stay tuned using
-twitter @navitia 
+twitter @navitia
 IRC #navitia on freenode
 https://groups.google.com/d/forum/navitia
 www.navitia.io
@@ -40,7 +40,7 @@ www.navitia.io
 #include "utils/functions.h"
 
 struct logger_initialized {
-    logger_initialized()   { init_logger(); }
+    logger_initialized()   { navitia::init_logger(); }
 };
 BOOST_GLOBAL_FIXTURE( logger_initialized );
 


### PR DESCRIPTION
I updated the **navitia logger**, now we have : 

- console
```
[18-09-11 14:40:11,209] [INFO ] [] - line_groups: 2 ed2nav.cpp:247                                                                       
[18-09-11 14:40:11,209] [INFO ] [] - route: 4 ed2nav.cpp:248                                                                             
[18-09-11 14:40:11,209] [INFO ] [] - stoparea: 11 ed2nav.cpp:249                                                                         
[18-09-11 14:40:11,209] [INFO ] [] - stoppoint: 8 ed2nav.cpp:250
```
- syslog
```
Sep 11 14:40:11 par-lap06 ed2nav: [25006] [INFO] [] - stop: 52 ed2nav.cpp:252
Sep 11 14:40:11 par-lap06 ed2nav: [25006] [INFO] [] - connection: 9 ed2nav.cpp:253
Sep 11 14:40:11 par-lap06 ed2nav: [25006] [INFO] [] - modes: 2 ed2nav.cpp:254
Sep 11 14:40:11 par-lap06 ed2nav: [25006] [INFO] [] - validity pattern : 2 ed2nav.cpp:255
Sep 11 14:40:11 par-lap06 ed2nav: [25006] [INFO] [] - calendars: 0 ed2nav.cpp:256
```