### PR TITLE
Add navitia::ptime noexcept default constructor

### DIFF
--- a/backtrace.h
+++ b/backtrace.h
@@ -42,7 +42,7 @@ namespace {
 std::string demangle( const char* const symbol )
 {
     const std::unique_ptr<char, decltype(&std::free)> demangled(
-                abi::__cxa_demangle(symbol, 0, 0, 0), &std::free);
+                abi::__cxa_demangle(symbol, nullptr, nullptr, nullptr), &std::free);
     if (demangled) {
         return demangled.get();
     }

--- a/configuration.cpp
+++ b/configuration.cpp
@@ -40,7 +40,7 @@ HINSTANCE hinstance = NULL;
 
 
 Configuration * Configuration::get() {
-    if (instance == 0) {
+    if (instance == nullptr) {
         instance = new Configuration();
 #ifdef WIN32
         char buf[2048];
@@ -55,7 +55,7 @@ Configuration * Configuration::get() {
 }
 
 bool Configuration::is_instanciated(){
-    return instance != 0;
+    return instance != nullptr;
 }
 
 void Configuration::load_ini(const std::string & filename){
@@ -102,4 +102,4 @@ void Configuration::set_int(const std::string & key, int value){
 }
 
 
-Configuration * Configuration::instance = 0;
+Configuration * Configuration::instance = nullptr;

--- a/lotus.cpp
+++ b/lotus.cpp
@@ -98,23 +98,23 @@ void Lotus::insert(std::vector<std::string> elements) {
 }
 
 void Lotus::finish_bulk_insert() {
-    int result_code =  PQputCopyEnd(this->connection, NULL);
+    int result_code =  PQputCopyEnd(this->connection, nullptr);
     if(result_code != 1){
         throw LotusException(std::string("finish bulk insert failed: ")
                              + PQerrorMessage(this->connection));
     }
 
-    PGresult *res = NULL;
+    PGresult *res = nullptr;
     do{
         PQclear(res);
-        res = NULL;
+        res = nullptr;
         res = PQgetResult(this->connection);
-        if(res != NULL && PQresultStatus(res) != PGRES_COMMAND_OK){
+        if(res != nullptr && PQresultStatus(res) != PGRES_COMMAND_OK){
             PQclear(res);
             throw LotusException(std::string("failed to finish bulk insert in final loop: ")
                                  + PQerrorMessage(this->connection));
         }
-    } while(res != NULL);
+    } while(res != nullptr);
 
 }
 

--- a/ptime.h
+++ b/ptime.h
@@ -28,6 +28,8 @@ https://groups.google.com/d/forum/navitia
 www.navitia.io
 */
 
+#pragma once
+
 #include <boost/date_time/posix_time/posix_time.hpp>
 
 namespace navitia {

--- a/ptime.h
+++ b/ptime.h
@@ -1,0 +1,61 @@
+/* Copyright © 2001-2018, Canal TP and/or its affiliates. All rights reserved.
+
+This file is part of Navitia,
+    the software to build cool stuff with public transport.
+
+Hope you'll enjoy and contribute to this project,
+    powered by Canal TP (www.canaltp.fr).
+Help us simplify mobility and open public transport:
+    a non ending quest to the responsive locomotion way of traveling!
+
+LICENCE: This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+Stay tuned using
+twitter @navitia
+IRC #navitia on freenode
+https://groups.google.com/d/forum/navitia
+www.navitia.io
+*/
+
+#include <boost/date_time/posix_time/posix_time.hpp>
+
+namespace navitia {
+
+class ptime: public boost::posix_time::ptime
+{
+public:
+    // Forward constructors
+    ptime(boost::gregorian::date d,time_duration_type td) : boost::posix_time::ptime(d,td)
+    {}
+    explicit ptime(boost::gregorian::date d) : boost::posix_time::ptime(d)
+    {}
+    ptime(const time_rep_type& rhs): boost::posix_time::ptime(rhs)
+    {}
+    ptime(const boost::date_time::special_values sv) : boost::posix_time::ptime(sv)
+    {}
+
+    // Add (copy-)constructor from ancestor
+    ptime(const boost::posix_time::ptime& rhs): boost::posix_time::ptime(rhs)
+    {}
+
+#if !defined(DATE_TIME_NO_DEFAULT_CONSTRUCTOR)
+    // Add noexcept default constructor
+    // Cause: Clang requires std::atomic content to have noexcept default constructor
+    ptime() noexcept: boost::posix_time::ptime()
+    {}
+#endif // DATE_TIME_NO_DEFAULT_CONSTRUCTOR
+
+};
+
+} // namespace navitia


### PR DESCRIPTION
This will fix clang compilation for Navitia

Clang requires std::atomic content to have noexcept default constructor
https://stackoverflow.com/questions/29483120/program-with-noexcept-constructor-accepted-by-gcc-rejected-by-clang

So navitia::ptime inherits from boost's one and implements it, to be used "atomically".

Bonus: remove few clang 6.0 warnings

TODO (`do_not_merge` labels for that):
- [x] wait for Navitia's PR https://github.com/CanalTP/navitia/pull/2615 using this to pass tests (then merge this PR, then update Navitia's PR)