### PR TITLE
update zmq loadbalancer to reuse the same worker most of the time

### DIFF
--- a/zmq.cpp
+++ b/zmq.cpp
@@ -80,7 +80,7 @@ void LoadBalancer::run(){
             zmq::message_t msg_request;
             clients.recv(&msg_request);
 
-            std::string worker_addr = avalailable_worker.front();
+            std::string worker_addr = avalailable_worker.top();
             avalailable_worker.pop();
 
             z_send(workers, worker_addr, ZMQ_SNDMORE);

--- a/zmq.h
+++ b/zmq.h
@@ -34,14 +34,14 @@ www.navitia.io
 
 #pragma once
 #include <zmq.hpp>
-#include <queue>
+#include <stack>
 
 void z_send(zmq::socket_t& socket, const std::string& str, int flags=0);
 void z_send(zmq::socket_t& socket, zmq::message_t& msg, int flags=0);
 std::string z_recv(zmq::socket_t& socket);
 
 class LoadBalancer{
-    std::queue<std::string> avalailable_worker;
+    std::stack<std::string> avalailable_worker;
     zmq::socket_t clients;
     zmq::socket_t workers;
     public:


### PR DESCRIPTION
This is mostly like https://github.com/CanalTP/navitia/pull/2551
This change aims to reduce the number of allocation done by kraken if it
doesn't have to do it.
Currently available workers are stored in a
queue, so every workers will handle a request a some point in time no
matter how much concurrent request there is.

Workers are now stored in a stack, so the last worker used will be
reused for handle the next requests. This will reduce the cost of
initializing workers when there isn't that many concurrent requests.

This is a optimization for big coverage (think transilien) that have a
lot of thread (80) to handle peak, but most of the time (outside of load
testing...) there are rarely more than a few concurrents requests on
kraken (4).

This should reduce response time after a data update or realtime update
and reduce memory consumption.