### PR TITLE
Remove giant lock in the ConcurrentLru :)

### DIFF
--- a/lru.h
+++ b/lru.h
@@ -146,6 +146,8 @@ public:
             std::lock_guard<std::mutex> lock(*mutex);
             future = lru(arg);
         }
+        // As arg might be a reference, the maybe newly created future must be run 
+        // before the end of the current method, else we can have a use after free.
         return future.get();
     }
 


### PR DESCRIPTION
The ConcurrentLru is the cache that back the raptor cache, its shared
between multiple threads and as such use synchronisation primitive to
prevent data race.
The previous implementation use a single mutex that prevent more than
one thread to use the cache simultaneously. The main drawback of this
approach is that creating the cache is done while holding the lock, so
while a thread is building a cache instance no other thread can build
another one, nor get an existing instance owned by the Lru.

The aim of this PR is to move the creation of the cache outside of the
lock to not block others threads.
This is done by leveraging the async features introduced in c++11.
The ConcurrentLru now cache `std::shared_future<std::shared_ptr<T>>`.
Only the creation of the lazy future (note [std::launch::deferred](https://en.cppreference.com/w/cpp/thread/launch))
and the LRU cache management is done with the lock held,
the cache creation is done when a thread try to obtain the content
of the future.

I have tested this implementation with the threads sanitizer and the
address sanitizer, both didn't found any errors.

Lock contention obtained with
`mutrace ./benchmark_raptor_cache -f transilien/data.nav.lz4 -s 10 -d 20 -t6`:
```
       Locked  Changed    Cont. tot.Time[ms] avg.Time[ms] max.Time[ms]
Before    342       17       16   110052.367      321.791      536.261
After     342      302       48     2064.289        6.036       23.979
```
|lru   |threads|real |user |sys  |miss|total|
|------|-------|-----|-----|---- |---|------|
|before| 1     |18.35|16.14|2.19 |57 |57    |
|after | 1     |18.81|16.48|2.31 |57 |57    |
|before| 2     |38.06|33.42|4.62 |112|114   |
|after | 2     |19.75|33.1 |4.46 |104|114   |
|before| 4     |71.32|62.57|8.72 |217|217   |
|after | 4     |25.71|82.97|13.25|197|217   |
|before| 6     |105.9|93.03|12.86|328|342   |
|after | 6     |33.79|151.7|26.17|290|342   |

With only one thread result are similar.
with more thread the new implementation is faster but use more cpu time
It migth be the allocator that have some issue to allocate so much
memory concurrently.