### PR TITLE
obj_factory : Add erase method

### DIFF
--- a/obj_factory.h
+++ b/obj_factory.h
@@ -48,6 +48,16 @@ private:
     inner_vector vec;
     inner_map map;
 
+    void reindex_and_erase(const uint idx)
+    {
+        // reindex idx elements
+        for (uint i = idx + 1; i < vec.size(); ++i) {
+            vec[i].get()->idx--;
+        }
+        // erase vec member
+        vec.erase(vec.begin() + idx);
+    }
+
 public:
     using iterator = typename inner_vector::iterator;
     using const_iterator = typename inner_vector::const_iterator;
@@ -102,12 +112,8 @@ public:
         return vec[idx.val].get();
     }
 
-    bool exist(const std::string& uri) {
-        if (map.find(uri) == map.end()) {
-            return false;
-        } else {
-            return true;
-        }
+    bool exists(const std::string& uri) const {
+        return (map.find(uri) != map.end());
     }
 
     bool erase(const Idx<ObjType>& idx) {
@@ -119,13 +125,12 @@ public:
         if (map.erase(elem_ptr->uri) == 0) {
             return false;
         }
-        // erase vec member
-        vec.erase(vec.begin() + idx.val);
+        reindex_and_erase(idx.val);
         return true;
     }
 
     bool erase(const std::string& uri) {
-        if (exist(uri) == false) {
+        if (exists(uri) == false) {
             return false;
         }
         const auto* elem_ptr = map.at(uri);
@@ -133,8 +138,7 @@ public:
         if (map.erase(uri) == 0) {
             return false;
         }
-        // erase vec member
-        vec.erase(vec.begin() + elem_ptr->idx);
+        reindex_and_erase(elem_ptr->idx);
         return true;
     }
 

--- a/obj_factory.h
+++ b/obj_factory.h
@@ -48,18 +48,6 @@ private:
     inner_vector vec;
     inner_map map;
 
-    bool shift_from(const uint start_idx) {
-        if (start_idx >= vec.size()) {
-            return false;
-        }
-        for (size_t i = start_idx; i < vec.size() - 1;  ++i) {
-            std::swap(vec[i], vec[i + 1]);
-        }
-        vec[vec.size() - 1].release();
-        vec.resize(vec.size() - 1);
-        return true;
-    }
-
 public:
     using iterator = typename inner_vector::iterator;
     using const_iterator = typename inner_vector::const_iterator;
@@ -127,21 +115,12 @@ public:
             return false;
         }
         // erase map menber
-        std::string finded_key;
         const auto* elem_ptr = vec[idx.val].get();
-        for (const auto& elem : map) {
-            if (elem.second == elem_ptr) {
-                finded_key = elem.first;
-                break;
-            }
-        }
-        if (finded_key.empty() || map.erase(finded_key) == 0) {
+        if (elem_ptr->uri.empty() || map.erase(elem_ptr->uri) == 0) {
             return false;
         }
         // erase vec menber
-        if (shift_from(idx.val) == false) {
-            return false;
-        }
+        vec.erase(vec.begin() + idx.val);
         return true;
     }
 
@@ -151,19 +130,7 @@ public:
         }
         // erase vec menber
         const auto* elem_ptr = map.at(uri);
-        int elem_idx = -1;
-        for (int i = 0; i < (int)vec.size(); ++i) {
-            if (vec[i].get() == elem_ptr) {
-                elem_idx = i;
-                break;
-            }
-        }
-        if (elem_idx == -1) {
-            return false;
-        }
-        if (shift_from(elem_idx) == false) {
-            return false;
-        }
+        vec.erase(vec.begin() + elem_ptr->idx);
         // erase map menber
         if (map.erase(uri) == 0) {
             return false;

--- a/obj_factory.h
+++ b/obj_factory.h
@@ -102,7 +102,7 @@ public:
         return vec[idx.val].get();
     }
 
-    bool if_exist(const std::string& uri) {
+    bool exist(const std::string& uri) {
         if (map.find(uri) == map.end()) {
             return false;
         } else {
@@ -114,27 +114,27 @@ public:
         if (idx.val >= vec.size()) {
             return false;
         }
-        // erase map menber
+        // erase map member
         const auto* elem_ptr = vec[idx.val].get();
-        if (elem_ptr->uri.empty() || map.erase(elem_ptr->uri) == 0) {
+        if (map.erase(elem_ptr->uri) == 0) {
             return false;
         }
-        // erase vec menber
+        // erase vec member
         vec.erase(vec.begin() + idx.val);
         return true;
     }
 
     bool erase(const std::string& uri) {
-        if (if_exist(uri) == false) {
+        if (exist(uri) == false) {
             return false;
         }
-        // erase vec menber
         const auto* elem_ptr = map.at(uri);
-        vec.erase(vec.begin() + elem_ptr->idx);
-        // erase map menber
+        // erase map member
         if (map.erase(uri) == 0) {
             return false;
         }
+        // erase vec member
+        vec.erase(vec.begin() + elem_ptr->idx);
         return true;
     }
 

--- a/obj_factory.h
+++ b/obj_factory.h
@@ -48,6 +48,18 @@ private:
     inner_vector vec;
     inner_map map;
 
+    bool shift_from(const uint start_idx) {
+        if (start_idx >= vec.size()) {
+            return false;
+        }
+        for (size_t i = start_idx; i < vec.size() - 1;  ++i) {
+            std::swap(vec[i], vec[i + 1]);
+        }
+        vec[vec.size() - 1].release();
+        vec.resize(vec.size() - 1);
+        return true;
+    }
+
 public:
     using iterator = typename inner_vector::iterator;
     using const_iterator = typename inner_vector::const_iterator;
@@ -100,6 +112,63 @@ public:
             return nullptr;
         }
         return vec[idx.val].get();
+    }
+
+    bool if_exist(const std::string& uri) {
+        if (map.find(uri) == map.end()) {
+            return false;
+        } else {
+            return true;
+        }
+    }
+
+    bool erase(const Idx<ObjType>& idx) {
+        if (idx.val >= vec.size()) {
+            return false;
+        }
+        // erase map menber
+        std::string finded_key;
+        const auto* elem_ptr = vec[idx.val].get();
+        for (const auto& elem : map) {
+            if (elem.second == elem_ptr) {
+                finded_key = elem.first;
+                break;
+            }
+        }
+        if (finded_key.empty() || map.erase(finded_key) == 0) {
+            return false;
+        }
+        // erase vec menber
+        if (shift_from(idx.val) == false) {
+            return false;
+        }
+        return true;
+    }
+
+    bool erase(const std::string& uri) {
+        if (if_exist(uri) == false) {
+            return false;
+        }
+        // erase vec menber
+        const auto* elem_ptr = map.at(uri);
+        int elem_idx = -1;
+        for (int i = 0; i < (int)vec.size(); ++i) {
+            if (vec[i].get() == elem_ptr) {
+                elem_idx = i;
+                break;
+            }
+        }
+        if (elem_idx == -1) {
+            return false;
+        }
+        if (shift_from(elem_idx) == false) {
+            return false;
+        }
+        // erase map menber
+        if (map.erase(uri) == 0) {
+            return false;
+        }
+        return true;
     }
 
     iterator begin() { return std::begin(vec); }

--- a/tests/obj_factory_test.cpp
+++ b/tests/obj_factory_test.cpp
@@ -102,7 +102,7 @@ BOOST_AUTO_TEST_CASE(non_copyable_obj_factory) {
     BOOST_CHECK_EQUAL(obj_factory.size(), 6);
 }
 
-BOOST_AUTO_TEST_CASE(erase_menber_into_obj_factory) {
+BOOST_AUTO_TEST_CASE(erase_member_into_obj_factory) {
 
     // Erase with uri key
     {

--- a/tests/obj_factory_test.cpp
+++ b/tests/obj_factory_test.cpp
@@ -1,28 +1,28 @@
 /* Copyright © 2001-2015, Canal TP and/or its affiliates. All rights reserved.
-  
+
 This file is part of Navitia,
     the software to build cool stuff with public transport.
- 
+
 Hope you'll enjoy and contribute to this project,
     powered by Canal TP (www.canaltp.fr).
 Help us simplify mobility and open public transport:
     a non ending quest to the responsive locomotion way of traveling!
-  
+
 LICENCE: This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
-   
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU Affero General Public License for more details.
-   
+
 You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
-  
+
 Stay tuned using
-twitter @navitia 
+twitter @navitia
 IRC #navitia on freenode
 https://groups.google.com/d/forum/navitia
 www.navitia.io
@@ -101,3 +101,82 @@ BOOST_AUTO_TEST_CASE(non_copyable_obj_factory) {
     BOOST_CHECK_EQUAL(*(obj_factory["OpenData"]->val), 4);
     BOOST_CHECK_EQUAL(obj_factory.size(), 6);
 }
+
+BOOST_AUTO_TEST_CASE(erase_menber_into_obj_factory) {
+
+    // Erase with uri key
+    {
+        for (size_t i = 0; i < 4; ++i) {
+
+            navitia::ObjFactory<HeaderInt> obj_factory;
+
+            std::array<std::string, 4> uris = {"Val_1", "Val_2", "Val_3", "Val_4"};
+            std::array<size_t, 4> values = {0, 1, 2, 3};
+
+            // Data
+            for (size_t j = 0; j < 4; ++j) {
+                auto data = HeaderInt();
+                data.val = values[j];
+                obj_factory.insert(uris[j], std::move(data));
+            }
+            BOOST_CHECK_EQUAL(obj_factory.size(), 4);
+            for (size_t j = 0; j < obj_factory.size(); ++j) {
+                BOOST_CHECK_EQUAL((obj_factory[uris[i]]->val), i);
+            }
+
+            // Erase with Idx
+            // Be carefull, erase function shifts (<<) elems inside vector
+            // It changes the idx for all shifted elems
+            BOOST_CHECK_EQUAL(obj_factory.erase("Val_10"), false);
+            BOOST_CHECK_EQUAL(obj_factory.erase(uris[i]), true);
+            BOOST_CHECK_EQUAL(obj_factory.size(), 3);
+            BOOST_CHECK_EQUAL(obj_factory.if_exist(uris[i]), false);
+            for (size_t j = 0; j < obj_factory.size(); ++j) {
+                if (j < i) {
+                    BOOST_CHECK_EQUAL(obj_factory.get_mut(navitia::Idx<HeaderInt>(j))->val, j);
+                }
+                else {
+                    BOOST_CHECK_EQUAL(obj_factory.get_mut(navitia::Idx<HeaderInt>(j))->val, j + 1);
+                }
+            }
+        }
+    }
+
+    // Erase with idx
+    {
+        for (size_t i = 0; i < 4; ++i) {
+
+            navitia::ObjFactory<HeaderInt> obj_factory;
+
+            std::array<std::string, 4> uris = {"Val_1", "Val_2", "Val_3", "Val_4"};
+            std::array<size_t, 4> values = {0, 1, 2, 3};
+
+            // Data
+            for (size_t j = 0; j < 4; ++j) {
+                auto data = HeaderInt();
+                data.val = values[j];
+                obj_factory.insert(uris[j], std::move(data));
+            }
+            BOOST_CHECK_EQUAL(obj_factory.size(), 4);
+            for (size_t j = 0; j < obj_factory.size(); ++j) {
+                BOOST_CHECK_EQUAL((obj_factory[uris[i]]->val), i);
+            }
+
+            // Erase with Idx
+            // Be carefull, erase function shifts elems inside vector
+            BOOST_CHECK_EQUAL(obj_factory.erase(navitia::Idx<HeaderInt>(10)), false);
+            BOOST_CHECK_EQUAL(obj_factory.erase(navitia::Idx<HeaderInt>(i)), true);
+            BOOST_CHECK_EQUAL(obj_factory.size(), 3);
+            BOOST_CHECK_EQUAL(obj_factory.if_exist(uris[i]), false);
+            for (size_t j = 0; j < obj_factory.size(); ++j) {
+                if (j < i) {
+                    BOOST_CHECK_EQUAL(obj_factory.get_mut(navitia::Idx<HeaderInt>(j))->val, j);
+                }
+                else {
+                    BOOST_CHECK_EQUAL(obj_factory.get_mut(navitia::Idx<HeaderInt>(j))->val, j + 1);
+                }
+            }
+        }
+    }
+}
+

--- a/tests/obj_factory_test.cpp
+++ b/tests/obj_factory_test.cpp
@@ -116,6 +116,7 @@ BOOST_AUTO_TEST_CASE(erase_menber_into_obj_factory) {
             // Data
             for (size_t j = 0; j < 4; ++j) {
                 auto data = HeaderInt();
+                data.idx = values[j];
                 data.val = values[j];
                 obj_factory.insert(uris[j], std::move(data));
             }
@@ -130,8 +131,9 @@ BOOST_AUTO_TEST_CASE(erase_menber_into_obj_factory) {
             BOOST_CHECK_EQUAL(obj_factory.erase("Val_10"), false);
             BOOST_CHECK_EQUAL(obj_factory.erase(uris[i]), true);
             BOOST_CHECK_EQUAL(obj_factory.size(), 3);
-            BOOST_CHECK_EQUAL(obj_factory.exist(uris[i]), false);
+            BOOST_CHECK_EQUAL(obj_factory.exists(uris[i]), false);
             for (size_t j = 0; j < obj_factory.size(); ++j) {
+                BOOST_CHECK_EQUAL(obj_factory.get_mut(navitia::Idx<HeaderInt>(j))->idx, j);
                 if (j < i) {
                     BOOST_CHECK_EQUAL(obj_factory.get_mut(navitia::Idx<HeaderInt>(j))->val, j);
                 }
@@ -154,6 +156,7 @@ BOOST_AUTO_TEST_CASE(erase_menber_into_obj_factory) {
             // Data
             for (size_t j = 0; j < 4; ++j) {
                 auto data = HeaderInt();
+                data.idx = values[j];
                 data.val = values[j];
                 obj_factory.insert(uris[j], std::move(data));
             }
@@ -167,8 +170,9 @@ BOOST_AUTO_TEST_CASE(erase_menber_into_obj_factory) {
             BOOST_CHECK_EQUAL(obj_factory.erase(navitia::Idx<HeaderInt>(10)), false);
             BOOST_CHECK_EQUAL(obj_factory.erase(navitia::Idx<HeaderInt>(i)), true);
             BOOST_CHECK_EQUAL(obj_factory.size(), 3);
-            BOOST_CHECK_EQUAL(obj_factory.exist(uris[i]), false);
+            BOOST_CHECK_EQUAL(obj_factory.exists(uris[i]), false);
             for (size_t j = 0; j < obj_factory.size(); ++j) {
+                BOOST_CHECK_EQUAL(obj_factory.get_mut(navitia::Idx<HeaderInt>(j))->idx, j);
                 if (j < i) {
                     BOOST_CHECK_EQUAL(obj_factory.get_mut(navitia::Idx<HeaderInt>(j))->val, j);
                 }

--- a/tests/obj_factory_test.cpp
+++ b/tests/obj_factory_test.cpp
@@ -110,7 +110,7 @@ BOOST_AUTO_TEST_CASE(erase_menber_into_obj_factory) {
 
             navitia::ObjFactory<HeaderInt> obj_factory;
 
-            std::array<std::string, 4> uris = {"Val_1", "Val_2", "Val_3", "Val_4"};
+            std::array<std::string, 4> uris = {"Val_0", "Val_1", "Val_2", "Val_3"};
             std::array<size_t, 4> values = {0, 1, 2, 3};
 
             // Data
@@ -130,7 +130,7 @@ BOOST_AUTO_TEST_CASE(erase_menber_into_obj_factory) {
             BOOST_CHECK_EQUAL(obj_factory.erase("Val_10"), false);
             BOOST_CHECK_EQUAL(obj_factory.erase(uris[i]), true);
             BOOST_CHECK_EQUAL(obj_factory.size(), 3);
-            BOOST_CHECK_EQUAL(obj_factory.if_exist(uris[i]), false);
+            BOOST_CHECK_EQUAL(obj_factory.exist(uris[i]), false);
             for (size_t j = 0; j < obj_factory.size(); ++j) {
                 if (j < i) {
                     BOOST_CHECK_EQUAL(obj_factory.get_mut(navitia::Idx<HeaderInt>(j))->val, j);
@@ -148,7 +148,7 @@ BOOST_AUTO_TEST_CASE(erase_menber_into_obj_factory) {
 
             navitia::ObjFactory<HeaderInt> obj_factory;
 
-            std::array<std::string, 4> uris = {"Val_1", "Val_2", "Val_3", "Val_4"};
+            std::array<std::string, 4> uris = {"Val_0", "Val_1", "Val_2", "Val_3"};
             std::array<size_t, 4> values = {0, 1, 2, 3};
 
             // Data
@@ -167,7 +167,7 @@ BOOST_AUTO_TEST_CASE(erase_menber_into_obj_factory) {
             BOOST_CHECK_EQUAL(obj_factory.erase(navitia::Idx<HeaderInt>(10)), false);
             BOOST_CHECK_EQUAL(obj_factory.erase(navitia::Idx<HeaderInt>(i)), true);
             BOOST_CHECK_EQUAL(obj_factory.size(), 3);
-            BOOST_CHECK_EQUAL(obj_factory.if_exist(uris[i]), false);
+            BOOST_CHECK_EQUAL(obj_factory.exist(uris[i]), false);
             for (size_t j = 0; j < obj_factory.size(); ++j) {
                 if (j < i) {
                     BOOST_CHECK_EQUAL(obj_factory.get_mut(navitia::Idx<HeaderInt>(j))->val, j);


### PR DESCRIPTION
Currently, it is not possible to reduce obj_factory. 
We want to erase any element but there is no method.

Useful, in Kraken to _suppress a MetaVJ_ in the realtime context.

The technique to suppress an element and reduce the vec size is the `shift elements inside the vector`.
see with @TeXitoi.

I know, you want to ask a question : is this not dangerous to change the MetaVJ Idx when you want to erase one? Maybe it can be handled in a piece of code ?
At the moment, we handle MetaVJ idx only in pt_referential part :
https://github.com/CanalTP/navitia/blob/dev/source/ptreferential/ptreferential_api.cpp#L117
https://github.com/CanalTP/navitia/blob/dev/source/type/data.cpp#L798
and apparently, this is not a problem because _pt_ref_  does not reload data after a real time update action (Dixit @TeXitoi )

