### PR TITLE
Remove clang warning on vtable emission

### DIFF
--- a/deadline.cpp
+++ b/deadline.cpp
@@ -33,6 +33,8 @@ www.navitia.io
 
 namespace navitia{
 
+    DeadlineExpired::~DeadlineExpired() = default;
+
     Deadline::Deadline() {}
     Deadline::Deadline(const boost::posix_time::ptime& deadline) : deadline(deadline) {}
     void Deadline::set(const boost::posix_time::ptime& deadline){

--- a/deadline.h
+++ b/deadline.h
@@ -37,6 +37,10 @@ namespace navitia{
 
     class DeadlineExpired: public recoverable_exception{
         using recoverable_exception::recoverable_exception;
+
+        public:
+        DeadlineExpired(const DeadlineExpired& o) = default;
+        virtual ~DeadlineExpired();
     };
 
     class Deadline{


### PR DESCRIPTION
Warnings removed:
`'DeadlineExpired' has no out-of-line virtual method definitions; its vtable will be emitted in every translation unit`
then
`definition of implicit copy constructor for 'DeadlineExpired' is deprecated because it has a user-declared destructor`

TODO:
- [x] wait for https://github.com/CanalTP/navitia/pull/2738 to build