### PR TITLE
overload contains method to accept initializer_list

### DIFF
--- a/functions.h
+++ b/functions.h
@@ -225,6 +225,10 @@ template<class Container, class Value>
 inline auto contains(const Container& c, const Value& x) -> decltype(std::end(c), true) {
     return impl::contains_impl(c, x, 0);
 }
+template<typename T, typename Value>
+inline auto contains(std::initializer_list<T> c, const Value& x) -> decltype(std::end(c), true) {
+    return impl::contains_impl(c, x, 0);
+}
 
 template<class Container, class Pred>
 inline bool contains_if(const Container& c, Pred p) {

--- a/functions.h
+++ b/functions.h
@@ -87,16 +87,6 @@ struct Less{
 
 };
 
-/**
- * tests if elt is in range range
- */
-template<typename T, typename U>
-bool in(const T& elt, std::initializer_list<U> range) {
-    for (const auto& cur: range)
-        if (elt == cur) return true;
-    return false;
-}
-
 /** Foncteur fixe le membre "idx" d'un objet en incrémentant toujours de 1
  *
  * Cela permet de numéroter tous les objets de 0 à n-1 d'un vecteur de pointeurs

--- a/tests/utils_test.cpp
+++ b/tests/utils_test.cpp
@@ -291,6 +291,9 @@ BOOST_AUTO_TEST_CASE(contains_test) {
     MockedContainerWithFind mocked_container;
     navitia::contains(mocked_container, 4);
     BOOST_CHECK_EQUAL(mocked_container.find_is_called, true);
+
+    BOOST_CHECK_EQUAL(navitia::contains({0, 1, 2}, 0), true);
+    BOOST_CHECK_EQUAL(navitia::contains({0, 1, 2}, 3), false);
 }
 
 BOOST_AUTO_TEST_CASE(math_mod_test) {


### PR DESCRIPTION
Following the closed PR https://github.com/CanalTP/utils/pull/81.
Goal: change in() by contains()

I need this change to do the first step for replacing `in()` function. Currently, into the code we have many `in()` calls done with `std::initlializer_list`.