### PR TITLE
clean up target link libs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 #uri base64 encoding activated by giving a ENABLE_URI_ENCODING variable to cmake
+
 IF(DEFINED ENABLE_URI_ENCODING)
     add_definitions(-DENABLE_URI_ENCODING)
 ENDIF(DEFINED ENABLE_URI_ENCODING)
@@ -42,7 +43,6 @@ SET(UTILS_SRC
 )
 
 add_library(utils ${UTILS_SRC})
-
-target_link_libraries(utils ${Boost_SYSTEM_LIBRARY} ${PQ_LIB} log4cplus config ${ZMQ_LIB})
+target_link_libraries(utils ${Boost_REGEX_LIBRARY} ${Boost_THREAD_LIBRARY} ${PQ_LIB} log4cplus config ${ZMQ_LIB})
 
 add_subdirectory(tests)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,34 +1,33 @@
 FIND_PACKAGE(Boost 1.55 COMPONENTS unit_test_framework thread regex serialization date_time REQUIRED)
 
 add_executable(utils_test utils_test.cpp)
-target_link_libraries(utils_test utils ${Boost_LIBRARIES} log4cplus)
-
+target_link_libraries(utils_test utils ${Boost_LIBRARIES})
 add_boost_test(utils_test)
 
 add_executable(csvreader_test csvreader_test.cpp)
-target_link_libraries(csvreader_test utils ${Boost_LIBRARIES} log4cplus)
+target_link_libraries(csvreader_test utils ${Boost_LIBRARIES})
 add_boost_test(csvreader_test)
 
 add_executable(lru_test lru_test.cpp)
-target_link_libraries(lru_test ${Boost_LIBRARIES} log4cplus)
+target_link_libraries(lru_test ${Boost_LIBRARIES})
 add_boost_test(lru_test)
 
 add_executable(idx_map_test idx_map_test.cpp)
-target_link_libraries(idx_map_test ${Boost_LIBRARIES} log4cplus)
+target_link_libraries(idx_map_test ${Boost_LIBRARIES})
 add_boost_test(idx_map_test)
 
 add_executable(multi_obj_pool_test multi_obj_pool_test.cpp)
-target_link_libraries(multi_obj_pool_test utils ${Boost_LIBRARIES} log4cplus)
+target_link_libraries(multi_obj_pool_test utils ${Boost_LIBRARIES})
 add_boost_test(multi_obj_pool_test)
 
 add_executable(obj_factory_test obj_factory_test.cpp)
-target_link_libraries(obj_factory_test utils ${Boost_LIBRARIES} log4cplus)
+target_link_libraries(obj_factory_test utils ${Boost_LIBRARIES})
 add_boost_test(obj_factory_test)
 
 add_executable(map_find_test map_find_test.cpp)
-target_link_libraries(map_find_test utils ${Boost_LIBRARIES} log4cplus)
+target_link_libraries(map_find_test utils ${Boost_LIBRARIES})
 add_boost_test(map_find_test)
 
 add_executable(deadline_test deadline_test.cpp)
-target_link_libraries(deadline_test utils ${Boost_LIBRARIES} log4cplus)
+target_link_libraries(deadline_test utils ${Boost_LIBRARIES})
 add_boost_test(deadline_test)


### PR DESCRIPTION
Clean up target dependencies by adding:
 *  log4cplus: init_logger - utils/logger.h
 * zmq : LoadBalancer - utils/zmq.h 
 * pq - Lotus - utils/lotus.h
 * boost regex: Coord parser
 * boost thread: Configuration - shared_mutex

This PR aims at bringing clean dependencies so we can discuss later on if they actually belong here.

Brace yourself  - This is the first PR that will lead to many more of the same kind 