### PR TITLE
Moved the `strip_accents` & `strip_accents_and_lower` functions

### DIFF
--- a/functions.cpp
+++ b/functions.cpp
@@ -96,4 +96,22 @@ std::string absolute_path(){
     }
 }
 
+std::string strip_accents(std::string str) {
+    const static std::vector<std::pair<std::string, std::string> > vec_str {
+        {"à", "a"}, {"À", "a"}, {"â", "a"}, {"Â", "a"}, {"ä", "a"},  {"Ä", "a"},  {"é", "e"},
+        {"É", "e"}, {"è", "e"}, {"È", "e"}, {"ê", "e"}, {"Ê", "e"},  {"ë", "e"},  {"Ë", "e"},
+        {"ô", "o"}, {"Ô", "o"}, {"ö", "o"}, {"Ö", "o"}, {"ò", "o"},  {"Ò", "o"},  {"û", "u"},
+        {"Û", "u"}, {"ù", "u"}, {"Ù", "u"}, {"ü", "u"}, {"Ü", "u"},  {"ç", "c"},  {"Ç", "c"},
+        {"ï", "i"}, {"Ï", "i"}, {"î", "i"}, {"Î", "i"}, {"œ", "oe"}, {"æ", "ae"}, {"’", "'"}};
+
+    for (const auto& vec : vec_str) {
+        boost::algorithm::replace_all(str, vec.first, vec.second);
+    }
+    return str;
+}
+
+std::string strip_accents_and_lower(const std::string& str) {
+    return boost::to_lower_copy(strip_accents(str));
+}
+
 } // namespace navitia

--- a/functions.h
+++ b/functions.h
@@ -126,10 +126,6 @@ struct pseudo_natural_sort {
     bool operator() (const std::string&, const std::string&) const;
 };
 
-/**
- * strip_accents_and_lower:
- * We compare strings: integers and accents are taken in account for the sort
- */
 std::string strip_accents(std::string str);
 std::string strip_accents_and_lower(const std::string& str);
 

--- a/functions.h
+++ b/functions.h
@@ -38,6 +38,8 @@ www.navitia.io
 #include <cstdio>
 #include <unistd.h>  // getcwd() definition
 
+#include <boost/algorithm/string/replace.hpp>
+#include <boost/algorithm/string/case_conv.hpp>
 #include <boost/range/algorithm/remove_if.hpp>
 #include <boost/range/algorithm/find_if.hpp>
 #include <boost/weak_ptr.hpp>
@@ -117,12 +119,19 @@ unique_ptr<T> make_unique(Args&& ...args) {
 namespace navitia {
 
 /**
- * speudo natural sort:
- * if both string cary integer, we compare them, else we compare the string
+ * pseudo natural sort:
+ * if both string carry integer, we compare them, else we compare the string
  */
 struct pseudo_natural_sort {
     bool operator() (const std::string&, const std::string&) const;
 };
+
+/**
+ * strip_accents_and_lower:
+ * We compare strings: integers and accents are taken in account for the sort
+ */
+std::string strip_accents(std::string str);
+std::string strip_accents_and_lower(const std::string& str);
 
 /**
  * sort_and_truncate:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -32,3 +32,7 @@ add_boost_test(map_find_test)
 add_executable(deadline_test deadline_test.cpp)
 target_link_libraries(deadline_test utils ${Boost_LIBRARIES} log4cplus)
 add_boost_test(deadline_test)
+
+add_executable(functions_test functions_test.cpp)
+target_link_libraries(functions_test utils ${Boost_LIBRARIES} log4cplus)
+add_boost_test(functions_test)

--- a/tests/functions_test.cpp
+++ b/tests/functions_test.cpp
@@ -1,0 +1,44 @@
+/* Copyright © 2001-2014, Canal TP and/or its affiliates. All rights reserved.
+
+This file is part of Navitia,
+    the software to build cool stuff with public transport.
+
+Hope you'll enjoy and contribute to this project,
+    powered by Canal TP (www.canaltp.fr).
+Help us simplify mobility and open public transport:
+    a non ending quest to the responsive locomotion way of traveling!
+
+LICENCE: This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+Stay tuned using
+twitter @navitia
+IRC #navitia on freenode
+https://groups.google.com/d/forum/navitia
+www.navitia.io
+*/
+
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE functions_test
+#include <boost/test/unit_test.hpp>
+#include "utils/functions.h"
+
+BOOST_AUTO_TEST_CASE(regex_strip_accents_and_lower_tests) {
+
+    std::string test("républiquê");
+    BOOST_CHECK_EQUAL(navitia::strip_accents(test), "republique");
+    test = "RÉpUblIquê";
+    BOOST_CHECK_EQUAL(navitia::strip_accents_and_lower(test), "republique");
+    test = "ÂâÄäçÇÉéÈèÊêËëÖöÔôÜüÎîÏïæœ";
+    BOOST_CHECK_EQUAL(navitia::strip_accents(test), "aaaacceeeeeeeeoooouuiiiiaeoe");
+}


### PR DESCRIPTION
Moved the `strip_accents` & `strip_accents_and_lower` functions from `source/autocomplete/autocomplete.h`
[Jira ticket NAVP-1446](https://jira.kisio.org/browse/NAVP-1446)