### PR TITLE
make zmq clients safer

### DIFF
--- a/zmq.cpp
+++ b/zmq.cpp
@@ -104,8 +104,10 @@ void LoadBalancer::run(){
 
             z_send(workers, worker_addr, ZMQ_SNDMORE);
             z_send(workers, "", ZMQ_SNDMORE);
+            // frames[0] is the id of message
             z_send(workers, frames[0], ZMQ_SNDMORE);
             z_send(workers, "", ZMQ_SNDMORE);
+            // frames[1] is the request
             z_send(workers, frames[2]);
         }
     }

--- a/zmq.cpp
+++ b/zmq.cpp
@@ -107,7 +107,7 @@ void LoadBalancer::run(){
             // frames[0] is the id of message
             z_send(workers, frames[0], ZMQ_SNDMORE);
             z_send(workers, "", ZMQ_SNDMORE);
-            // frames[1] is the request
+            // frames[2] is the request
             z_send(workers, frames[2]);
         }
     }

--- a/zmq.cpp
+++ b/zmq.cpp
@@ -17,6 +17,19 @@ std::string z_recv(zmq::socket_t& socket){
     return std::string(static_cast<char*>(msg.data()), msg.size());
 }
 
+namespace {
+
+void purge_and_reply(zmq::socket_t& clients, int more, bool should_purge) {
+
+    size_t more_size = sizeof (more);
+	while(more && should_purge) {
+		z_recv(clients);
+		clients.getsockopt(ZMQ_RCVMORE, &more, &more_size);
+	}
+	z_send(clients, "");
+}
+
+} // end namespace
 
 LoadBalancer::LoadBalancer(zmq::context_t& context):
             clients(context, ZMQ_ROUTER), workers(context, ZMQ_ROUTER){
@@ -68,18 +81,53 @@ void LoadBalancer::run(){
         }
         //handle clients request
         if (items[1].revents & ZMQ_POLLIN){
+            // The client request is a multi-part ZMQ message, we have to check every frame and be sure the multi-part message frame
+            // is composed as we wish, otherwise the multi-part message may be shifted unexpectedly.
+
+            int more;
+            size_t more_size = sizeof (more);
+
             //first we get the client id
             zmq::message_t msg_identity;
             clients.recv(&msg_identity);
-            {
-                //then an empty frame
-                std::string empty = z_recv(clients);
-                assert(empty.size() == 0);
+            // Are there more frames coming?
+            clients.getsockopt(ZMQ_RCVMORE, &more, &more_size);
+            assert(more == 1);
+
+            // We're waiting for an empty frame...
+            // If no more frames, we reply immediately
+            if (more == 0) {
+                bool should_purge = false;
+                purge_and_reply(clients, more, should_purge);
+                continue;
+            }
+
+            //then an empty frame, there should be another frame follows up...
+            std::string empty = z_recv(clients);
+            clients.getsockopt(ZMQ_RCVMORE, &more, &more_size);
+            assert(empty.empty());
+            assert(more == 1);
+
+            if (!empty.empty() || more == 0){
+                // Case 1: If no more frames follow up, we reply and return
+                // Case 2: the current frame is NOT empty, so we consider it as a bad request, we purge the queue and then reply
+                bool should_purge = true;
+                purge_and_reply(clients, more, should_purge);
+                continue;
             }
 
             zmq::message_t msg_request;
             clients.recv(&msg_request);
+            clients.getsockopt(ZMQ_RCVMORE, &more, &more_size);
+            assert(more == 0);
 
+            if (more != 0) {
+                // the current frame must be the last frame, if there are more frames coming, we consider it as a bad request
+                // we purge the queue and then reply same as what's done above
+                bool should_purge = true;
+                purge_and_reply(clients, more, should_purge);
+                continue;
+            }
             std::string worker_addr = avalailable_worker.top();
             avalailable_worker.pop();
 

--- a/zmq.cpp
+++ b/zmq.cpp
@@ -87,7 +87,7 @@ void LoadBalancer::run(){
 
             std::vector<zmq::message_t> frames{};
             do {
-            	zmq::message_t frame;
+                zmq::message_t frame;
                 clients.recv(&frame);
                 frames.push_back(std::move(frame));
                 // Are there more frames coming?


### PR DESCRIPTION
This PR allows us to check the client request more in detail.

With the current implementation, the client request (ex: a request from Jormungandr) is a ZMQ multi-part message(http://api.zeromq.org/2-1:zmq-recv) received by a ROUTER socket(http://zguide.zeromq.org/php:chapter3#The-Extended-Reply-Envelope).  

The request must be unpacked, frame by frame, in a specific way.  If a bad multi-part message, which is not enveloped as it should be, is sent to the client, bad chunks may remain in the queue and pollute all coming requests, in this case, all frames may be shifted.... 

Here is a script allows to make the bug appear
```python
import zmq
context = zmq.Context()
socket = context.socket(zmq.REQ)
socket.connect("tcp://localhost:6000")
socket.send("123", zmq.SNDMORE)
socket.send("456", zmq.SNDMORE)
socket.send("42")

if socket.poll(timeout=2 * 1000) > 0:
    print("OK")
    pb = socket.recv()
else:
    socket.setsockopt(zmq.LINGER, 0)
    print("KO")
```

Note from ZMQ:

> 
> Multi-part messages
> 
> A 0MQ message is composed of 1 or more message parts. 0MQ ensures atomic delivery of messages: peers shall receive either all message parts of a message or none at all. The total number of message parts is unlimited except by available memory

